### PR TITLE
Change CDN URL to link to development build

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <!-- libraries neded for this page -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.13/vue.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.13/vue.js"></script>
     <!-- support for this page -->
     <link rel="stylesheet" href="css/todo_list.css">
     <script src="js/todo_list.js" async></script>


### PR DESCRIPTION
The URL in the lab links to the production/minified version, which the Vue devtools extension is automatically disabled on. In order to use the extension, change it to the development build.